### PR TITLE
Add URLSearchParams and Console API

### DIFF
--- a/GLOBALS.md
+++ b/GLOBALS.md
@@ -44,5 +44,5 @@ Environments supported:
 Spec: https://console.spec.whatwg.org
 
 Environments supported:
-- Web
+- [Web](https://developer.mozilla.org/en-US/docs/Web/API/console)
 - [Node.js](https://nodejs.org/api/console.html)

--- a/GLOBALS.md
+++ b/GLOBALS.md
@@ -17,7 +17,7 @@ Spec: https://url.spec.whatwg.org
 
 Environments supported:
 - [Web](https://developer.mozilla.org/en-US/docs/Web/API/URL#Browser_compatibility)
-- [Node.js]: [URL](https://nodejs.org/api/url.html) and [URLSearchParams](https://nodejs.org/api/url.html#url_class_urlsearchparams)
+- Node.js: [URL](https://nodejs.org/api/url.html) and [URLSearchParams](https://nodejs.org/api/url.html#url_class_urlsearchparams)
 
 Compatibility: Node.js implements the same interface, modulo brand checks and IDL mistakes in Node.js (TODO: be more specific)
 

--- a/GLOBALS.md
+++ b/GLOBALS.md
@@ -21,6 +21,14 @@ Environments supported:
 
 Compatibility: Node.js implements the same interface, modulo brand checks and IDL mistakes in Node.js (TODO: be more specific)
 
+### URLSearchParams
+
+Spec: https://url.spec.whatwg.org/#interface-urlsearchparams
+
+Environments supported:
+- [Web](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)
+- [Node.js](https://nodejs.org/api/url.html#url_class_urlsearchparams)
+
 ### Encoding standard
 
 Spec: https://encoding.spec.whatwg.org
@@ -38,3 +46,11 @@ Spec: https://www.w3.org/TR/wasm-js-api-1/
 Environments supported:
 - [Web](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly)
 - Node.js: not documented yet
+
+### Console API
+
+Spec: https://console.spec.whatwg.org
+
+Environments supported:
+- Web
+- [Node.js](https://nodejs.org/api/console.html)

--- a/GLOBALS.md
+++ b/GLOBALS.md
@@ -17,17 +17,9 @@ Spec: https://url.spec.whatwg.org
 
 Environments supported:
 - [Web](https://developer.mozilla.org/en-US/docs/Web/API/URL#Browser_compatibility)
-- [Node.js](https://nodejs.org/api/url.html)
+- [Node.js]: [URL](https://nodejs.org/api/url.html) and [URLSearchParams](https://nodejs.org/api/url.html#url_class_urlsearchparams)
 
 Compatibility: Node.js implements the same interface, modulo brand checks and IDL mistakes in Node.js (TODO: be more specific)
-
-### URLSearchParams
-
-Spec: https://url.spec.whatwg.org/#interface-urlsearchparams
-
-Environments supported:
-- [Web](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)
-- [Node.js](https://nodejs.org/api/url.html#url_class_urlsearchparams)
 
 ### Encoding standard
 


### PR DESCRIPTION
Actually URLSearchParams is part of URL spec. Should it be mentioned as separate global here?